### PR TITLE
Remove keyspace name in cql when creating tables

### DIFF
--- a/src/main/resources/cgmes_assembling.cql
+++ b/src/main/resources/cgmes_assembling.cql
@@ -1,32 +1,32 @@
-CREATE TABLE IF NOT EXISTS cgmes_assembling.handled_files (
+CREATE TABLE IF NOT EXISTS handled_files (
     filename text,
     origin text,
     handled_date timestamp,
     PRIMARY KEY (filename, origin)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_assembling.filename_by_uuid (
+CREATE TABLE IF NOT EXISTS filename_by_uuid (
     uuid text,
     filename text,
     origin text,
     PRIMARY KEY (uuid, origin)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_assembling.uuid_by_filename (
+CREATE TABLE IF NOT EXISTS uuid_by_filename (
     filename text,
     uuid text,
     origin text,
     PRIMARY KEY (filename, origin)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_assembling.imported_files (
+CREATE TABLE IF NOT EXISTS imported_files (
     filename text,
     origin text,
     import_date timestamp,
     PRIMARY KEY (filename, origin)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_assembling.dependencies (
+CREATE TABLE IF NOT EXISTS dependencies (
     uuid text,
     dependencies frozen<List<text>>,
     PRIMARY KEY (uuid)

--- a/src/test/java/org/gridsuite/cgmes/assembling/job/ProfilesAcquisitionJobTest.java
+++ b/src/test/java/org/gridsuite/cgmes/assembling/job/ProfilesAcquisitionJobTest.java
@@ -41,7 +41,9 @@ public class ProfilesAcquisitionJobTest {
 
     @ClassRule
     public static final CassandraRule CASSANDRA_RULE = new CassandraRule().withCassandraFactory(EmbeddedCassandraFactoryConfig.embeddedCassandraFactory())
-                                                                          .withCqlDataSet(CqlDataSet.ofClasspaths("create_keyspace.cql", "cgmes_assembling.cql"));
+                                                                          .withCqlDataSet(CqlDataSet.ofClasspaths("create_keyspace.cql")
+                                                                          .add(CqlDataSet.ofStrings("USE cgmes_assembling;"))
+                                                                          .add(CqlDataSet.ofClasspaths("cgmes_assembling.cql")));
 
     @ClassRule
     public static final FakeSftpServerRule SFTP_SERVER_RULE = new FakeSftpServerRule().addUser("dummy", "dummy").setPort(2222);


### PR DESCRIPTION
otherwise it can't work with other keyspace name (ex: prefixed names), fix tests to use keyspace first